### PR TITLE
feat(db): add parts table migration

### DIFF
--- a/backend/migrations/20250426185825_create_parts.sql
+++ b/backend/migrations/20250426185825_create_parts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE parts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    part_number TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    kind TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+)


### PR DESCRIPTION
## Overview
`parts` テーブルを作成するマイグレーションを追加しました。

## Details
- `id` カラムは UUID、自動生成
- `part_number`、`name` は必須項目
- `description`、`kind` は任意
- `created_at`、`updated_at` はタイムスタンプ自動設定

## Purpose
今後のパーツ管理機能(API実装など)のための土台作りです。
