### PR TITLE
feat(api): add GET /parts endpoint

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -22,6 +22,7 @@ name = "app"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "serde",
  "tokio",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
+serde = { version = "1.0", features = ["derive"]}

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,0 +1,23 @@
+use axum::Json;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct Part {
+    id: String,
+    part_number: String,
+    name: String,
+    description: String,
+    kind: String,
+}
+
+pub async fn get_parts() -> Json<Vec<Part>> {
+    let parts = vec![Part {
+        id: "00000000-0000-0000-0000-000000000001".to_string(),
+        part_number: "ABC-123".to_string(),
+        name: "ねじ".to_string(),
+        description: "ステンレス製のねじ".to_string(),
+        kind: "部品".to_string(),
+    }];
+
+    Json(parts)
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,8 @@
+mod handlers;
+
 use axum::Router;
 use axum::routing::get;
+use handlers::get_parts;
 use tokio::net::TcpListener;
 
 async fn health_check() -> &'static str {
@@ -8,7 +11,9 @@ async fn health_check() -> &'static str {
 
 #[tokio::main]
 async fn main() {
-    let app = Router::new().route("/healthz", get(health_check));
+    let app = Router::new()
+        .route("/healthz", get(health_check))
+        .route("/parts", get(get_parts));
     let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
     println!("Server running at http://localhost:3000");
     axum::serve(listener, app).await.unwrap();


### PR DESCRIPTION
## Overview
`/parts` エンドポイントを追加しました。  
仮データを返却するGET APIを実装しています。

## Details
- エンドポイント：`GET /parts`
- レスポンスには以下のフィールドを含むパーツデータを返却
  - `id`（UUID）
  - `part_number`（パーツ番号）
  - `name`（パーツ名）
  - `description`（説明）
  - `kind`（種別）
- データは仮データで、現時点ではDB接続は行っていません。
- ハンドラーは `backend/src/handlers.rs` に実装しています。

## Purpose
今後、パーツデータ管理機能を開発していくための土台作りです。  
まずはフロントエンドからデータ取得できるAPIインターフェースを提供することを目的としています。
