### PR TITLE
feat(api): implement POST /parts and improve GET /parts

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "axum",
  "serde",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -165,6 +166,18 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -316,7 +329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -393,6 +406,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "redox_syscall"
@@ -607,10 +626,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "windows-sys"
@@ -684,3 +721,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"]}
+uuid = { version = "1", features = ["v4"] }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,8 +2,11 @@ mod handlers;
 
 use axum::Router;
 use axum::routing::get;
+use handlers::create_part;
 use handlers::get_parts;
+use std::sync::Arc;
 use tokio::net::TcpListener;
+use tokio::sync::Mutex;
 
 async fn health_check() -> &'static str {
     "OK"
@@ -11,9 +14,12 @@ async fn health_check() -> &'static str {
 
 #[tokio::main]
 async fn main() {
+    let shared_part = Arc::new(Mutex::new(Vec::new()));
+
     let app = Router::new()
         .route("/healthz", get(health_check))
-        .route("/parts", get(get_parts));
+        .route("/parts", get(get_parts).post(create_part))
+        .with_state(shared_part);
     let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
     println!("Server running at http://localhost:3000");
     axum::serve(listener, app).await.unwrap();


### PR DESCRIPTION
## Overview
- `POST /parts` エンドポイントを実装しました。
- これによりクライアント側から新しいパーツを追加できるようになりました。

## Details
- UUIDはサーバ側で自動生成
- 登録データはメモリ上（Vec<Part>）に保存
- `GET /parts`も実装を修正し、登録されたデータをリアルタイムに取得できるよう改善

## Purpose
- パーツ管理機能の土台を作成するための基盤開発です。
- 今後、DB保存やエラーハンドリングを拡張予定です。
