### PR TITLE
feat(api): Add GET /parts/{id} endpoint

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,3 +1,5 @@
+use axum::extract::Path;
+use axum::http::StatusCode;
 use axum::{Json, extract::State};
 use serde::Deserialize;
 use serde::Serialize;
@@ -49,4 +51,16 @@ pub async fn create_part(
     parts_lock.push(part.clone());
 
     Json(part)
+}
+
+pub async fn get_part(
+    State(parts): State<PartState>,
+    Path(id): Path<String>,
+) -> Result<Json<Part>, StatusCode> {
+    let parts_lock = parts.lock().await;
+    if let Some(part) = parts_lock.iter().find(|p| p.id == id) {
+        Ok(Json(part.clone()))
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,6 +3,7 @@ mod handlers;
 use axum::Router;
 use axum::routing::get;
 use handlers::create_part;
+use handlers::get_part;
 use handlers::get_parts;
 use std::sync::Arc;
 use tokio::net::TcpListener;
@@ -19,6 +20,7 @@ async fn main() {
     let app = Router::new()
         .route("/healthz", get(health_check))
         .route("/parts", get(get_parts).post(create_part))
+        .route("/parts/{id}", get(get_part))
         .with_state(shared_part);
     let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
     println!("Server running at http://localhost:3000");


### PR DESCRIPTION
## Overview
`GET /parts/{id}` エンドポイントを新規追加しました。  
これにより、登録されているパーツ情報を個別に取得できるようになります。

## Details
- `handlers.rs` に `get_part` ハンドラーを追加
  - `State`と`Path`エクストラクターを使用して、パーツリストから特定IDのパーツを検索
  - 存在すれば `200 OK` + パーツデータ(JSON)を返却
  - 存在しなければ `404 Not Found` を返却
- `main.rs` に `/parts/{id}` ルートを追加
  - `Router::route("/parts/{id}", get(get_part))` 形式にて設定

## Purpose
今後のパーツ管理機能（更新・削除機能など）に向けて、個別パーツの取得機能を提供するため。