### PR TITLE
feat(api): Add PUT /parts/{id} endpoint

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,8 +1,5 @@
-use axum::extract::Path;
-use axum::http::StatusCode;
-use axum::{Json, extract::State};
-use serde::Deserialize;
-use serde::Serialize;
+use axum::{Json, extract::Path, extract::State, http::StatusCode};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -59,6 +56,24 @@ pub async fn get_part(
 ) -> Result<Json<Part>, StatusCode> {
     let parts_lock = parts.lock().await;
     if let Some(part) = parts_lock.iter().find(|p| p.id == id) {
+        Ok(Json(part.clone()))
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+pub async fn update_part(
+    State(parts): State<PartState>,
+    Path(id): Path<String>,
+    Json(updated_part): Json<NewPart>,
+) -> Result<Json<Part>, StatusCode> {
+    let mut parts_lock = parts.lock().await;
+    if let Some(part) = parts_lock.iter_mut().find(|p| p.id == id) {
+        part.part_number = updated_part.part_number;
+        part.name = updated_part.name;
+        part.description = updated_part.description;
+        part.kind = updated_part.kind;
+
         Ok(Json(part.clone()))
     } else {
         Err(StatusCode::NOT_FOUND)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,13 +1,9 @@
 mod handlers;
 
-use axum::Router;
-use axum::routing::get;
-use handlers::create_part;
-use handlers::get_part;
-use handlers::get_parts;
+use axum::{Router, routing::get};
+use handlers::{create_part, get_part, get_parts, update_part};
 use std::sync::Arc;
-use tokio::net::TcpListener;
-use tokio::sync::Mutex;
+use tokio::{net::TcpListener, sync::Mutex};
 
 async fn health_check() -> &'static str {
     "OK"
@@ -20,7 +16,7 @@ async fn main() {
     let app = Router::new()
         .route("/healthz", get(health_check))
         .route("/parts", get(get_parts).post(create_part))
-        .route("/parts/{id}", get(get_part))
+        .route("/parts/{id}", get(get_part).put(update_part))
         .with_state(shared_part);
     let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
     println!("Server running at http://localhost:3000");


### PR DESCRIPTION
## Overview
既存のパーツ情報を更新するための `PUT /parts/{id}` エンドポイントを追加しました。

## Details
- `handlers.rs` に `update_part` 関数を追加
  - 受け取ったJSONデータで対象パーツを上書き
  - 対象パーツが存在しない場合は404エラーを返却
- `main.rs` に `PUT /parts/{id}` ルートを設定

## Purpose
パーツ情報の更新機能を提供し、CRUD操作の充実を図るため。