### PR TITLE
feat(api): Add DELETE /parts/{id} endpoint

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -79,3 +79,16 @@ pub async fn update_part(
         Err(StatusCode::NOT_FOUND)
     }
 }
+
+pub async fn delete_part(
+    State(parts): State<PartState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    let mut parts_lock = parts.lock().await;
+    if let Some(pos) = parts_lock.iter().position(|p| p.id == id) {
+        parts_lock.remove(pos);
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,7 +1,7 @@
 mod handlers;
 
 use axum::{Router, routing::get};
-use handlers::{create_part, get_part, get_parts, update_part};
+use handlers::{create_part, delete_part, get_part, get_parts, update_part};
 use std::sync::Arc;
 use tokio::{net::TcpListener, sync::Mutex};
 
@@ -16,7 +16,10 @@ async fn main() {
     let app = Router::new()
         .route("/healthz", get(health_check))
         .route("/parts", get(get_parts).post(create_part))
-        .route("/parts/{id}", get(get_part).put(update_part))
+        .route(
+            "/parts/{id}",
+            get(get_part).put(update_part).delete(delete_part),
+        )
         .with_state(shared_part);
     let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
     println!("Server running at http://localhost:3000");


### PR DESCRIPTION
## Overview
登録されているパーツ情報を削除するための `DELETE /parts/{id}` エンドポイントを追加しました。

## Details
- `handlers.rs` に `delete_part` 関数を追加
  - 指定されたIDに一致するパーツを削除
  - 削除成功時には `204 No Content` を返却
  - 存在しない場合は `404 Not Found` を返却
- `main.rs` に `DELETE /parts/{id}` のルーティング設定を追加

## Purpose
CRUD操作のうち、削除(Delete)機能を提供し、パーツ管理の機能を完成させるため。