### PR TITLE
feat: Improve validation error handling by returning JSON responses

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "chrono",
  "dotenvy",
  "serde",
+ "serde_json",
  "sqlx",
  "tokio",
  "uuid",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,3 +12,4 @@ chrono = { version = "0.4", features = ["serde"] }
 sqlx = { version = "0.8", features = [ "runtime-tokio", "postgres", "macros", "chrono", "uuid" ] }
 dotenvy = "0.15"
 validator = { version = "0.20", features = ["derive"] }
+serde_json = "1.0"


### PR DESCRIPTION
## Overview
バリデーションエラー発生時に、エラーメッセージをJSON形式で返すよう改善しました。

## Details
- `ValidationErrorResponse`型を新規作成
- create_part, update_partのバリデーションエラー時にJSONレスポンスを返すように変更
- これによりフロントエンド側でエラー処理がしやすくなりました

## Purpose
APIのエラー応答の品質向上と、フロントエンド実装時の開発体験向上のため。
