### PR TITLE
feat: Add standardized success response format across all endpoints

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -110,8 +110,38 @@ fn extract_validation_errors(errors: ValidationErrors) -> ValidationErrorRespons
 
 #[derive(Debug, Serialize)]
 pub struct SuccessResponse<T> {
+    pub success: bool,
     pub code: u16,
     pub data: T,
+}
+
+impl<T> SuccessResponse<T> {
+    pub fn ok(data: T) -> Self {
+        SuccessResponse {
+            success: true,
+            code: StatusCode::OK.as_u16(),
+            data,
+        }
+    }
+
+    pub fn created(data: T) -> Self {
+        SuccessResponse {
+            success: true,
+            code: StatusCode::CREATED.as_u16(),
+            data,
+        }
+    }
+
+    pub fn no_content() -> Self
+    where
+        T: Default,
+    {
+        SuccessResponse {
+            success: true,
+            code: StatusCode::NO_CONTENT.as_u16(),
+            data: T::default(),
+        }
+    }
 }
 
 #[derive(sqlx::FromRow, Serialize)]
@@ -163,10 +193,7 @@ pub async fn create_part(
     })?;
 
     info!("Part created successfully: {}", part.id);
-    Ok(Json(SuccessResponse {
-        code: StatusCode::CREATED.as_u16(),
-        data: part,
-    }))
+    Ok(Json(SuccessResponse::created(part)))
 }
 
 // #[axum::debug_handler]
@@ -187,10 +214,7 @@ pub async fn get_parts(
     })?;
 
     info!("Fetched {} parts successfully", parts.len());
-    Ok(Json(SuccessResponse {
-        code: StatusCode::OK.as_u16(),
-        data: parts,
-    }))
+    Ok(Json(SuccessResponse::ok(parts)))
 }
 
 // #[axum::debug_handler]
@@ -216,10 +240,7 @@ pub async fn get_part(
     match part {
         Some(part) => {
             info!("Part found: {}", part.id);
-            Ok(Json(SuccessResponse {
-                code: StatusCode::OK.as_u16(),
-                data: part,
-            }))
+            Ok(Json(SuccessResponse::ok(part)))
         }
         None => {
             info!("Part not found: {}", id);
@@ -265,10 +286,7 @@ pub async fn update_part(
     match part {
         Some(part) => {
             info!("Part updated successfully: {}", part.id);
-            Ok(Json(SuccessResponse {
-                code: StatusCode::OK.as_u16(),
-                data: part,
-            }))
+            Ok(Json(SuccessResponse::ok(part)))
         }
         None => {
             info!("Part not found for update: {}", id);
@@ -301,9 +319,6 @@ pub async fn delete_part(
         )))
     } else {
         info!("Part deleted successfully: {}", id);
-        Ok(Json(SuccessResponse {
-            code: StatusCode::NO_CONTENT.as_u16(),
-            data: (),
-        }))
+        Ok(Json(SuccessResponse::no_content()))
     }
 }


### PR DESCRIPTION
## Overview
- 成功時の API レスポンス形式を統一し、クライアント側の処理簡素化と一貫性の向上を図りました。

## Details
- SuccessResponse<T> 構造体を導入し、以下の3フィールドを定義:
  - success: true（固定）
  - code: u16（HTTP ステータスコード）
  - data: T（レスポンスデータ）
- 全エンドポイント（create_part / get_parts / get_part / update_part / delete_part）で SuccessResponse を使用するよう修正
- レスポンスボディが null となる DELETE にも対応
- ログ出力の一貫性を確認済み

## Purpose
- API の成功レスポンスを統一形式に揃えることで、クライアントサイドの実装やレスポンスパース処理を簡潔にするため
- 今後の他エンドポイント拡張時にも共通形式でレスポンス設計できるようにするため