### PR TITLE
feat: unify success and error response formats

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -9,12 +9,13 @@ use validator::{Validate, ValidationErrors};
 
 #[derive(Debug, Serialize)]
 pub struct ErrorResponse {
+    pub success: bool,
+    pub code: u16,
     pub error: ErrorDetail,
 }
 
 #[derive(Debug, Serialize)]
 pub struct ErrorDetail {
-    pub code: u16,
     pub message: String,
 }
 
@@ -36,7 +37,7 @@ impl IntoResponse for AppError {
                     "Validation error ({}): {} error(s) - {:?}",
                     status,
                     errors.errors.len(),
-                    errors
+                    errors.errors
                 );
 
                 let body = Json(errors);
@@ -49,10 +50,9 @@ impl IntoResponse for AppError {
                 error!("NotFound error ({}): {}", status, message);
 
                 let body = Json(ErrorResponse {
-                    error: ErrorDetail {
-                        code: status.as_u16(),
-                        message,
-                    },
+                    success: false,
+                    code: status.as_u16(),
+                    error: ErrorDetail { message },
                 });
 
                 (status, body).into_response()
@@ -63,10 +63,9 @@ impl IntoResponse for AppError {
                 error!("Database error ({}): {}", status, message);
 
                 let body = Json(ErrorResponse {
-                    error: ErrorDetail {
-                        code: status.as_u16(),
-                        message,
-                    },
+                    success: false,
+                    code: status.as_u16(),
+                    error: ErrorDetail { message },
                 });
 
                 (status, body).into_response()
@@ -78,6 +77,8 @@ impl IntoResponse for AppError {
 
 #[derive(Serialize, Debug)]
 pub struct ValidationErrorResponse {
+    pub success: bool,
+    pub code: u16,
     pub errors: Vec<FieldError>,
 }
 
@@ -104,6 +105,8 @@ fn extract_validation_errors(errors: ValidationErrors) -> ValidationErrorRespons
         }
     }
     ValidationErrorResponse {
+        success: false,
+        code: StatusCode::BAD_REQUEST.as_u16(),
         errors: field_errors,
     }
 }


### PR DESCRIPTION
## Overview
- 成功・エラー応答のフォーマット統一を行いました。
- バリデーションエラー時と通常エラー時で、適切なレスポンス形式に整理しました。

## Details
- 成功時: { success: true, code: number, data: any }
- バリデーションエラー時: { success: false, code: 400, errors: FieldError[] }
- 通常エラー時: { success: false, code: number, error: { message: string } }
- ログ出力もステータスコードとエラーメッセージを含めて改善しました。

## Purpose
- フロントエンドとのAPI連携を容易にし、エラー処理を簡素化するため。
- レスポンスの一貫性を確保して、将来的な保守性を高めるため。