### PR TITLE
refactor: hide DB error details from client responses

### DIFF
--- a/backend/src/services/part/create.rs
+++ b/backend/src/services/part/create.rs
@@ -27,7 +27,7 @@ pub async fn create_part(pool: &PgPool, new_part: NewPart) -> Result<Part, AppEr
     .await
     .map_err(|e| {
         error!("DB error during part insertion: {}", e);
-        AppError::DatabaseError(format!("DB insert failed: {}", e))
+        AppError::DatabaseError("DB insert failed".to_string())
     })?;
 
     info!("Part created successfully: {}", part.id);

--- a/backend/src/services/part/delete.rs
+++ b/backend/src/services/part/delete.rs
@@ -10,7 +10,7 @@ pub async fn delete_part(pool: &PgPool, id: Uuid) -> Result<(), AppError> {
         .await
         .map_err(|e| {
             error!("DB error during deleting part: {}", e);
-            AppError::DatabaseError(format!("Failed to delete part: {}", e))
+            AppError::DatabaseError("Failed to delete part".to_string())
         })?;
 
     if result.rows_affected() == 0 {

--- a/backend/src/services/part/get.rs
+++ b/backend/src/services/part/get.rs
@@ -16,7 +16,7 @@ pub async fn get_parts(pool: &PgPool) -> Result<Vec<Part>, AppError> {
     .await
     .map_err(|e| {
         error!("DB error during fetching parts: {}", e);
-        AppError::DatabaseError(format!("DB select failed: {}", e))
+        AppError::DatabaseError("DB select failed".to_string())
     })?;
 
     info!("Fetched {} parts successfully", parts.len());
@@ -36,7 +36,7 @@ pub async fn get_part(pool: &PgPool, id: Uuid) -> Result<Part, AppError> {
     .await
     .map_err(|e| {
         error!("DB error during fetching part: {}", e);
-        AppError::DatabaseError(format!("Failed to fetch part: {}", e))
+        AppError::DatabaseError("Failed to fetch part".to_string())
     })?;
 
     match part {

--- a/backend/src/services/part/update.rs
+++ b/backend/src/services/part/update.rs
@@ -33,7 +33,7 @@ pub async fn update_part(pool: &PgPool, id: Uuid, updated_part: NewPart) -> Resu
     .await
     .map_err(|e| {
         error!("DB error during updating part: {}", e);
-        AppError::DatabaseError(format!("Failed to update part: {}", e))
+        AppError::DatabaseError("Failed to update part".to_string())
     })?;
 
     match part {


### PR DESCRIPTION
セキュリティの観点でAppError::DatabaseError(...)の内容を修正
ログには詳細を出してるが、クライアントには簡素化するようにしました。