### PR TITLE
fix: restrict CORS origin via env variable and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,14 @@ Then open: [http://localhost:3000/healthz](http://localhost:3000/healthz) to che
 Create a `.env` file in the `backend/` directory:
 
 ```env
+# Database
 DATABASE_URL=postgres://user:pass@db:5432/plmdb
+# Authentication (JWT)
 JWT_SECRET=your_jwt_secret
+# CORS
+# 開発時: フロントエンドのURLを指定
+# 本番時: https://your-app.com などに変更
+CORS_ORIGIN=http://localhost:5173
 ```
 
 Use `.env.example` as a reference.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,8 @@
-# Auth
+# Database
+# DATABASE_URL=postgres://user:pass@db:5432/plmdb
+# Authentication (JWT)
 JWT_SECRET=your_jwt_secret
+# CORS
+# 開発時: フロントエンドのURLを指定
+# 本番時: https://your-app.com などに変更
+CORS_ORIGIN=http://localhost:5173


### PR DESCRIPTION
## 🔧 CORS 設定の厳格化

この PR では、環境変数を使って **CORS オリジンを限定**できるようにしました。

### ✨ 変更内容

* `CORS_ORIGIN` 環境変数により、許可するオリジンを明示的に指定可能に
* `.env.example` と `README.md` を更新し、開発・本番での切り替え方法を記載

### ✅ 環境変数例

```env
CORS_ORIGIN=http://localhost:5173
```

### 📝 備考

* ワイルドカード `"*"` は許容していません（セキュリティ上の理由）