### PR TITLE
test(api): Add full API integration tests with curl and Docker Compose

### DIFF
--- a/Dockerfile.test-runner
+++ b/Dockerfile.test-runner
@@ -1,0 +1,14 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y curl bash jq && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+COPY tests/api ./tests/
+
+RUN chmod +x ./tests/part/api_test.sh ./tests/wait-for-backend.sh
+
+# CMD ["./tests/part/api_test.sh"]
+CMD ["bash", "-c", "./tests/wait-for-backend.sh && ./tests/part/api_test.sh"]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ DATABASE_URL=postgres://user:pass@db:5432/plmdb
 
 ```bash
 cd backend
-cargo sqlx migrate run
 cargo run
 ```
 
@@ -134,12 +133,64 @@ curl.exe -X GET "http://localhost:3000/parts" `
 
 ---
 
-<!-- ## 🧪 Run Tests
+## 🧪 Run Tests
+
+You can run **unit tests** (e.g. validation logic) using Cargo:
 
 ```bash
 cd backend
 cargo test
-``` -->
+````
+
+And you can run **full API integration tests** using Docker Compose:
+
+```bash
+docker-compose -f docker-compose.backend.test.yml --project-name test up --build --abort-on-container-exit
+```
+
+Sample output when all tests pass:
+
+```
+test-runner-1  | 🎉 All API tests passed!
+test-runner-1 exited with code 0
+Aborting on container exit...
+✔ Container test-test-runner-1  Stopped
+✔ Container test-backend-1      Stopped
+✔ Container test-db-1           Stopped
+```
+
+### What this does
+
+* 🔧 Builds backend, database, and test-runner containers
+* 🕒 Waits for the backend to be ready (`/healthz`)
+* 🧪 Executes test scripts in `tests/api`
+* 🧹 Cleans up all containers after execution
+
+### Test Structure
+
+Test logic is defined in:
+
+```
+tests/api/part/api_test.sh
+```
+
+It covers:
+
+* ✅ Health check
+* ✅ User signup & login
+* ✅ JWT-protected routes (`/parts`)
+* ✅ Validation errors
+* ✅ CRUD: Create, Get, Update, Delete
+
+
+> 💡 **Note**:  
+> If the full API integration tests fail during backend compilation (due to missing `.sqlx` data), try running:
+>
+> ```bash
+> cargo sqlx prepare --workspace -- --locked
+> ```
+>
+> This generates `.sqlx` data required for offline SQLx builds inside the Docker image.
 
 ---
 

--- a/backend/.sqlx/query-13094923a6a4e0bf2f6c81cb8b7a13a5dd5e0177663bfc8c843893d4cc484321.json
+++ b/backend/.sqlx/query-13094923a6a4e0bf2f6c81cb8b7a13a5dd5e0177663bfc8c843893d4cc484321.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM users WHERE login_name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "13094923a6a4e0bf2f6c81cb8b7a13a5dd5e0177663bfc8c843893d4cc484321"
+}

--- a/backend/.sqlx/query-4188e2affe53eb55975440c0bb79c2cc3db64b3340a12374fad4c6e973ce242a.json
+++ b/backend/.sqlx/query-4188e2affe53eb55975440c0bb79c2cc3db64b3340a12374fad4c6e973ce242a.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, part_number, name, description, kind, created_at, updated_at\n        FROM parts\n        WHERE id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "part_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "kind",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "4188e2affe53eb55975440c0bb79c2cc3db64b3340a12374fad4c6e973ce242a"
+}

--- a/backend/.sqlx/query-60ff056bad837a8b66752141a9ddbbe5498df44430b223252a0c0892467a8c30.json
+++ b/backend/.sqlx/query-60ff056bad837a8b66752141a9ddbbe5498df44430b223252a0c0892467a8c30.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM parts WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "60ff056bad837a8b66752141a9ddbbe5498df44430b223252a0c0892467a8c30"
+}

--- a/backend/.sqlx/query-67a73815d4a2814f0ee52c16861d24bb1687304fc3e1574c695a0be182779b4f.json
+++ b/backend/.sqlx/query-67a73815d4a2814f0ee52c16861d24bb1687304fc3e1574c695a0be182779b4f.json
@@ -1,0 +1,56 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, part_number, name, description, kind, created_at, updated_at\n        FROM parts\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "part_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "kind",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "67a73815d4a2814f0ee52c16861d24bb1687304fc3e1574c695a0be182779b4f"
+}

--- a/backend/.sqlx/query-c348907362006765f64c437a296dbe858e82f54ae0b7eb7d8adeb9c1515c8bd2.json
+++ b/backend/.sqlx/query-c348907362006765f64c437a296dbe858e82f54ae0b7eb7d8adeb9c1515c8bd2.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO users\n        (login_name, password_hash)\n        VALUES ($1, $2)\n        RETURNING id, login_name, password_hash, created_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "login_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "password_hash",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "c348907362006765f64c437a296dbe858e82f54ae0b7eb7d8adeb9c1515c8bd2"
+}

--- a/backend/.sqlx/query-e07af55a76c87a9f4c79df8f45ecb54538114abdc030e7c85951e41c4a2c9448.json
+++ b/backend/.sqlx/query-e07af55a76c87a9f4c79df8f45ecb54538114abdc030e7c85951e41c4a2c9448.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, login_name, password_hash, created_at\n        FROM users\n        WHERE login_name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "login_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "password_hash",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "e07af55a76c87a9f4c79df8f45ecb54538114abdc030e7c85951e41c4a2c9448"
+}

--- a/backend/.sqlx/query-ebdd0247c4252b17950c137a25e9e5d5c96668ca97e2f4533d5b80003a317305.json
+++ b/backend/.sqlx/query-ebdd0247c4252b17950c137a25e9e5d5c96668ca97e2f4533d5b80003a317305.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE parts\n        SET part_number = $1,\n            name = $2,\n            description = $3,\n            kind = $4,\n            updated_at = NOW()\n        WHERE id = $5\n        RETURNING id, part_number, name, description, kind, created_at, updated_at\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "part_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "kind",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "ebdd0247c4252b17950c137a25e9e5d5c96668ca97e2f4533d5b80003a317305"
+}

--- a/backend/.sqlx/query-f43c47b8cb05bc988f6a709953460c22ee7ee36fd6f59ccad258b73ca09a16b4.json
+++ b/backend/.sqlx/query-f43c47b8cb05bc988f6a709953460c22ee7ee36fd6f59ccad258b73ca09a16b4.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO parts (id, part_number, name, description, kind)\n           VALUES ($1, $2, $3, $4, $5)\n           RETURNING id, part_number, name, description, kind, created_at, updated_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "part_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "kind",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "f43c47b8cb05bc988f6a709953460c22ee7ee36fd6f59ccad258b73ca09a16b4"
+}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,53 @@
+# ビルドステージ
+FROM rust:slim AS builder
+
+RUN apt-get update
+
+RUN rustup update && \
+    rustup component add rustfmt && \
+    rustup component add clippy
+
+RUN apt-get install -y unzip libssl-dev pkg-config
+RUN cargo install sqlx-cli --no-default-features --features native-tls,postgres
+
+WORKDIR /usr/src/app
+# COPY . .
+
+# 必要な依存キャッシュを効かせるために先にCargoファイルをコピー
+COPY Cargo.toml Cargo.lock ./
+# RUN mkdir src && echo "fn main() {}" > src/main.rs
+# ビルド
+# 一度失敗しても依存ダウンロードは終わっている
+# RUN cargo build --release || true  
+
+# COPY . .
+COPY .sqlx .sqlx
+COPY src ./src
+COPY .env .env
+COPY migrations ./migrations
+
+ENV SQLX_OFFLINE=true
+
+# RUN cargo install --path .
+RUN cargo build --release
+# RUN cargo install --path . --locked
+
+# ランタイムステージ
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y unzip libssl-dev pkg-config ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+    
+    # && apt-get install -y libssl-dev pkg-config \
+
+WORKDIR /workspace
+# COPY --from=builder /usr/local/cargo/bin/app /usr/local/bin/app
+# COPY --from=builder /usr/src/app/target/release/app /usr/local/bin/app
+COPY --from=builder /usr/src/app/target/release/ .
+COPY --from=builder /usr/src/app/.env .env
+# WORKDIR /usr/local/bin
+
+# EXPOSE 8080
+CMD ["./app"]
+# ENTRYPOINT ["./app"]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -49,6 +49,12 @@ async fn main() {
 
     info!("Successfully connected to the database");
 
+    // マイグレーションの自動実行
+    if let Err(err) = sqlx::migrate!("./migrations").run(&pool).await {
+        error!("Failed to run database migrations: {}", err);
+        panic!("Migration error");
+    }
+
     let cors = CorsLayer::new()
         .allow_origin(
             cors_origin

--- a/docker-compose.backend.test.yml
+++ b/docker-compose.backend.test.yml
@@ -1,0 +1,39 @@
+# version: '3.9'
+
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    working_dir: /workspace
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+    # command: sleep infinity
+  db:
+    image: postgres
+    # restart: always
+    volumes:
+      - type: tmpfs
+        target: /var/lib/postgresql/data
+        tmpfs:
+          size: 134217728
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+  test-runner:
+    build:
+      context: .
+      dockerfile: Dockerfile.test-runner
+    depends_on:
+      - backend
+    # volumes:
+    #   - ./tests/api:/workspace/tests
+
+# volumes:

--- a/tests/api/part/api_test.sh
+++ b/tests/api/part/api_test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+API_URL="http://backend:3000"
+ORIGIN_HEADER="Origin: http://localhost:5173"
+
+echo "=== 🧪 Running health check ==="
+curl -sf "$API_URL/healthz" | grep "OK" >/dev/null || {
+  echo "❌ Health check failed"
+  exit 1
+}
+echo "✅ Health check passed"
+
+echo "=== 🧪 Signing up ==="
+signup_res=$(curl -s -X POST "$API_URL/signup" \
+  -H "Content-Type: application/json" \
+  -d '{"login_name":"testuser","password":"password123"}')
+
+echo "$signup_res" | jq .
+code=$(echo "$signup_res" | jq -r '.code')
+
+if [ "$code" == "201" ]; then
+  echo "✅ Signup successful"
+elif [ "$code" == "409" ]; then
+  echo "⚠️  Already signed up"
+else
+  echo "❌ Unexpected signup response"
+  exit 1
+fi
+
+echo "=== 🧪 Logging in ==="
+login_res=$(curl -s -X POST "$API_URL/login" \
+  -H "Content-Type: application/json" \
+  -d '{"login_name":"testuser","password":"password123"}')
+
+echo "$login_res" | jq .
+token=$(echo "$login_res" | jq -r '.data.token')
+
+if [ "$token" == "null" ] || [ -z "$token" ]; then
+  echo "❌ Login failed"
+  exit 1
+fi
+echo "✅ Login successful"
+
+AUTH_HEADER="Authorization: Bearer $token"
+
+echo "=== 🧪 Creating a part ==="
+part_res=$(curl -s -X POST "$API_URL/parts" \
+  -H "Content-Type: application/json" \
+  -H "$AUTH_HEADER" \
+  -H "$ORIGIN_HEADER" \
+  -d '{"part_number":"XYZ-789","name":"ボルト","description":"大型用","kind":"部品"}')
+
+echo "$part_res" | jq .
+part_id=$(echo "$part_res" | jq -r '.data.id')
+
+if [ "$part_id" == "null" ] || [ -z "$part_id" ]; then
+  echo "❌ Part creation failed"
+  exit 1
+fi
+echo "✅ Part created with ID: $part_id"
+
+echo "=== 🧪 Getting created part ==="
+get_part=$(curl -s -X GET "$API_URL/parts/$part_id" \
+  -H "$AUTH_HEADER" -H "$ORIGIN_HEADER")
+echo "$get_part" | jq .
+
+echo "=== 🧪 Updating part with invalid data ==="
+update_res=$(curl -s -X PUT "$API_URL/parts/$part_id" \
+  -H "Content-Type: application/json" \
+  -H "$AUTH_HEADER" -H "$ORIGIN_HEADER" \
+  -d '{"part_number":"","name":"ボルト","description":"大型用","kind":"部品"}')
+
+echo "$update_res" | jq .
+update_code=$(echo "$update_res" | jq -r '.code')
+if [ "$update_code" != "400" ]; then
+  echo "❌ Expected validation error, got: $update_code"
+  exit 1
+fi
+echo "✅ Validation for update worked"
+
+echo "=== 🧪 Deleting part ==="
+delete_res=$(curl -s -X DELETE "$API_URL/parts/$part_id" \
+  -H "$AUTH_HEADER")
+echo "$delete_res" | jq .
+echo "✅ Part deleted"
+
+echo "🎉 All API tests passed!"

--- a/tests/api/wait-for-backend.sh
+++ b/tests/api/wait-for-backend.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+API_URL="http://backend:3000"
+
+echo "⏳ Waiting for backend at $API_URL/healthz..."
+
+for i in {1..30}; do
+  status=$(curl -s -o /dev/null -w "%{http_code}" "$API_URL/healthz" || true)
+  if [ "$status" = "200" ]; then
+    echo "✅ Backend is up!"
+    exit 0
+  fi
+  echo "Waiting... ($i) status=$status"
+  sleep 2
+done
+
+echo "❌ Backend did not become healthy in time."
+exit 1


### PR DESCRIPTION
## 概要

RustバックエンドのAPI統合テストを自動で実行する仕組みを追加しました。  
Docker Composeにより、バックエンド・DB・テストランナーを構築・実行し、curlベースのスモークテストを行います。

---

## 変更内容

- `docker-compose.backend.test.yml` を追加
- `test-runner` コンテナを導入（curl + bash + jq）
- `/healthz` を待ってからテストを実行する `wait-for-backend.sh` を実装
- テスト本体：`tests/api/part/api_test.sh`
- `.sqlx` のオフラインビルド用データも含め、Docker内で正常にビルドされるよう調整
- `README.md` に実行手順と注意事項を追記

---

## 実行方法（ローカル）

```bash
docker-compose -f docker-compose.backend.test.yml --project-name test up --build --abort-on-container-exit
