### PR TITLE
docs(readme): Add Swagger UI access and API documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,23 @@ It covers:
 
 ---
 
+## 📚 API Documentation (Swagger UI)
+
+You can view the OpenAPI documentation in your browser after launching the backend:
+
+* Open: [http://localhost:3000/docs](http://localhost:3000/docs)
+
+It includes:
+
+* ✅ Auth endpoints (`/signup`, `/login`)
+* ✅ Part management (`/parts`, `/parts/{id}`)
+* ✅ Schema definitions (`Part`, `NewPart`, etc.)
+* ✅ Error/Validation responses
+
+> If you're modifying routes or models, documentation is automatically updated thanks to [`utoipa`](https://docs.rs/utoipa/latest/utoipa/) and [`utoipa-swagger-ui`](https://docs.rs/utoipa-swagger-ui/latest/).
+
+---
+
 ## 📁 Project Structure
 
 ```

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -64,8 +64,19 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
+ "utoipa-swagger-ui",
  "uuid",
  "validator",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -309,6 +320,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +406,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -469,6 +500,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -943,6 +984,7 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1062,6 +1104,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1445,6 +1497,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5fbc0ee50fcb99af7cebb442e5df7b5b45e9460ffa3f8f549cd26b862bec49d"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf418c9a2e3f6663ca38b8a7134cc2c2167c9d69688860e8961e3faa731702e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d55b95147fe01265d06b3955db798bdaed52e60e2211c41137701b3aba8e21"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1560,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1590,6 +1685,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simple_asn1"
@@ -2152,6 +2253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,6 +2313,49 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utoipa"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77d306bc75294fd52f3e99b13ece67c02c1a2789190a6f31d32f736624326f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29519b3c485df6b13f4478ac909a491387e9ef70204487c3b64b53749aec0be"
+dependencies = [
+ "axum",
+ "base64",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
 
 [[package]]
 name = "uuid"
@@ -2264,6 +2414,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -2369,6 +2529,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2695,4 +2864,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,3 +19,5 @@ tower-http = { version = "0.6", features = ["trace", "cors"] }
 jsonwebtoken = "9"
 argon2 = "0.5"
 hashed_password = "1"
+utoipa = { version = "5", features = ["uuid", "chrono", "axum_extras"]}
+utoipa-swagger-ui = { version = "9", features = ["axum"] }

--- a/backend/src/auth/domain.rs
+++ b/backend/src/auth/domain.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Claims {
@@ -6,24 +7,24 @@ pub struct Claims {
     pub exp: usize,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct SignupRequest {
     pub login_name: String,
     pub password: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SignupResponse {
     pub login_name: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct LoginRequest {
     pub login_name: String,
     pub password: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct LoginResponse {
     pub token: String,
 }

--- a/backend/src/auth/route.rs
+++ b/backend/src/auth/route.rs
@@ -1,5 +1,6 @@
-use crate::auth::domain::{LoginRequest, LoginResponse, SignupResponse};
-use crate::auth::{domain::SignupRequest, service as auth_service};
+use crate::auth::domain::{LoginRequest, LoginResponse, SignupRequest, SignupResponse};
+use crate::auth::service as auth_service;
+use crate::responses::error::ErrorResponse;
 use crate::responses::success::SuccessResponse;
 
 use axum::{Json, extract::State};
@@ -7,6 +8,17 @@ use sqlx::PgPool;
 
 use crate::errors::app_error::AppError;
 
+#[utoipa::path(
+    post,
+    path = "/signup",
+    request_body = SignupRequest,
+    responses(
+        (status = 201, description = "User created successfully", body = SuccessResponse<SignupResponse>),
+        (status = 409, description = "Conflict (already exists)", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tags = ["auth"]
+)]
 pub async fn signup(
     State(pool): State<PgPool>,
     Json(payload): Json<SignupRequest>,
@@ -15,6 +27,17 @@ pub async fn signup(
     Ok(Json(SuccessResponse::created(signup_response)))
 }
 
+#[utoipa::path(
+    post,
+    path = "/login",
+    request_body = LoginRequest,
+    responses(
+        (status = 200, description = "Login successful", body = SuccessResponse<LoginResponse>),
+        (status = 401, description = "Unauthorized (invalid credentials)", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tags = ["auth"]
+)]
 pub async fn login(
     State(pool): State<PgPool>,
     Json(payload): Json<LoginRequest>,

--- a/backend/src/errors/app_error.rs
+++ b/backend/src/errors/app_error.rs
@@ -4,8 +4,9 @@ use crate::responses::error::{ErrorDetail, ErrorResponse};
 use axum::response::{IntoResponse, Response};
 use axum::{Json, http::StatusCode};
 use tracing::error;
+use utoipa::ToSchema;
 
-#[derive(Debug)]
+#[derive(Debug, ToSchema)]
 pub enum AppError {
     ValidationError(ValidationErrorResponse),
     NotFound(String),

--- a/backend/src/errors/validation.rs
+++ b/backend/src/errors/validation.rs
@@ -1,15 +1,18 @@
 use axum::http::StatusCode;
 use serde::Serialize;
+use utoipa::ToSchema;
 use validator::ValidationErrors;
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub struct ValidationErrorResponse {
+    #[schema(example = false)]
     pub success: bool,
+    #[schema(example = 400)]
     pub code: u16,
     pub errors: Vec<FieldError>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub struct FieldError {
     pub field: String,
     pub message: String,

--- a/backend/src/models/part.rs
+++ b/backend/src/models/part.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use uuid::Uuid;
 use validator::Validate;
 
-#[derive(sqlx::FromRow, Serialize)]
+#[derive(sqlx::FromRow, Serialize, ToSchema)]
 pub struct Part {
     pub id: Uuid,
     pub part_number: String,
@@ -14,7 +15,7 @@ pub struct Part {
     pub updated_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Deserialize, Validate)]
+#[derive(Deserialize, Validate, ToSchema)]
 pub struct NewPart {
     #[validate(length(min = 1, message = "part_number must not be empty"))]
     pub part_number: String,

--- a/backend/src/responses/error.rs
+++ b/backend/src/responses/error.rs
@@ -1,13 +1,15 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ErrorResponse {
+    #[schema(example = false)]
     pub success: bool,
     pub code: u16,
     pub error: ErrorDetail,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ErrorDetail {
     pub message: String,
 }

--- a/backend/src/responses/success.rs
+++ b/backend/src/responses/success.rs
@@ -1,8 +1,10 @@
 use axum::http::StatusCode;
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SuccessResponse<T> {
+    #[schema(example = true)]
     pub success: bool,
     pub code: u16,
     pub data: T,

--- a/backend/src/routes/parts.rs
+++ b/backend/src/routes/parts.rs
@@ -1,5 +1,7 @@
 use crate::errors::app_error::AppError;
+use crate::errors::validation::ValidationErrorResponse;
 use crate::models::part::{NewPart, Part};
+use crate::responses::error::ErrorResponse;
 use crate::responses::success::SuccessResponse;
 use crate::services::part::{
     create_part as service_create_part, delete_part as service_delete_part,
@@ -13,6 +15,12 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 // #[axum::debug_handler]
+#[utoipa::path(post, path = "/parts", request_body = NewPart, responses(
+    (status = 201, description = "Part created successfully", body = SuccessResponse<Part>),
+    (status = 400, description = "Validation error", body = ValidationErrorResponse),
+    (status = 401, description = "Unauthorized error", body = ErrorResponse),
+    (status = 500, description = "Database error", body = ErrorResponse),
+), tags = ["parts"], security(("bearerAuth" = [])))]
 pub async fn create_part(
     State(pool): State<PgPool>,
     Json(new_part): Json<NewPart>,
@@ -22,6 +30,11 @@ pub async fn create_part(
 }
 
 // #[axum::debug_handler]
+#[utoipa::path(get, path = "/parts", responses(
+    (status = 200, description = "Fetched parts successfully", body = SuccessResponse<Vec<Part>>),
+    (status = 401, description = "Unauthorized error", body = ErrorResponse),
+    (status = 500, description = "Database error", body = ErrorResponse),
+), tags = ["parts"], security(("bearerAuth" = [])))]
 pub async fn get_parts(
     State(pool): State<PgPool>,
 ) -> Result<Json<SuccessResponse<Vec<Part>>>, AppError> {
@@ -30,6 +43,12 @@ pub async fn get_parts(
 }
 
 // #[axum::debug_handler]
+#[utoipa::path(get, path = "/parts/{id}", params(("id" = Uuid, Path, description = "Part ID to fetch")),  responses(
+    (status = 200, description = "Fetched part successfully", body = SuccessResponse<Part>),
+    (status = 401, description = "Unauthorized error", body = ErrorResponse),
+    (status = 404, description = "NotFound error", body = ErrorResponse),
+    (status = 500, description = "Database error", body = ErrorResponse),
+), tags = ["parts"], security(("bearerAuth" = [])))]
 pub async fn get_part(
     State(pool): State<PgPool>,
     Path(id): Path<Uuid>,
@@ -39,6 +58,13 @@ pub async fn get_part(
 }
 
 // #[axum::debug_handler]
+#[utoipa::path(put, path = "/parts/{id}", params(("id" = Uuid, Path, description = "Part ID to update")) , request_body = NewPart, responses(
+    (status = 200, description = "Part updated successfully", body = SuccessResponse<Part>),
+    (status = 400, description = "Validation error", body = ValidationErrorResponse),
+    (status = 401, description = "Unauthorized error", body = ErrorResponse),
+    (status = 404, description = "NotFound error", body = ErrorResponse),
+    (status = 500, description = "Database error", body = ErrorResponse),
+), tags = ["parts"], security(("bearerAuth" = [])))]
 pub async fn update_part(
     State(pool): State<PgPool>,
     Path(id): Path<Uuid>,
@@ -49,6 +75,12 @@ pub async fn update_part(
 }
 
 // #[axum::debug_handler]
+#[utoipa::path(delete, path = "/parts/{id}", params(("id" = Uuid, Path, description = "Part ID to delete")) , responses(
+    (status = 204, description = "Part deleted successfully"),
+    (status = 401, description = "Unauthorized error", body = ErrorResponse),
+    (status = 404, description = "NotFound error", body = ErrorResponse),
+    (status = 500, description = "Database error", body = ErrorResponse),
+), tags = ["parts"], security(("bearerAuth" = [])))]
 pub async fn delete_part(
     State(pool): State<PgPool>,
     Path(id): Path<Uuid>,


### PR DESCRIPTION
### 概要

この PR では、`utoipa` / `utoipa-swagger-ui` を導入し、Swagger UI による OpenAPI ドキュメント生成と表示を実装しました。あわせて、`README.md` に関連情報を追記しています。

### ✅ 主な変更点

* `utoipa`, `utoipa-swagger-ui` の導入（`Cargo.toml` / `Cargo.lock` 更新）
* `#[derive(ToSchema)]` の追加による構造体スキーマの定義
* `#[utoipa::path(...)]` によるエンドポイントのドキュメント化
* Swagger UI を `/docs` にマウント（OpenAPI JSON は `/api-docs/openapi.json`）
* `README.md` にアクセス方法と使い方を追加

### 📌 Swagger UI 確認方法

1. 開発環境でバックエンドを起動
2. 以下にアクセス
   👉 [http://localhost:3000/docs](http://localhost:3000/docs)

### 📝 補足

* 各 API のバリデーションエラーや認証失敗もスキーマに記述
* `SuccessResponse<T>` や `ErrorResponse` など共通レスポンス構造も含めてドキュメント化
* 今後の拡張に備えて `tags = ["parts", "auth"]` を設定済み