### PR TITLE
feat(part): enforce ownership-based authorization for update and delete (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ curl.exe -X GET "http://localhost:3000/parts" `
   -H "Authorization: Bearer <your_token_here>"
 ```
 
+### 🛡 Authorization Rules
+
+Some endpoints require that the user owns the resource being modified:
+
+| Endpoint               | Rule                           |
+|------------------------|--------------------------------|
+| `PUT /parts/{id}`      | User must own the part         |
+| `DELETE /parts/{id}`   | User must own the part         |
+
+If the resource does not belong to the user, a `401 Unauthorized` error is returned.
+
+
 ---
 
 ## 🧪 Run Tests

--- a/backend/.sqlx/query-199cd317b871bac81a3bb5ece3ccfaaad8e3144bd2cf21acd7d525cd3d32c874.json
+++ b/backend/.sqlx/query-199cd317b871bac81a3bb5ece3ccfaaad8e3144bd2cf21acd7d525cd3d32c874.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT created_by FROM parts WHERE ID = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "created_by",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "199cd317b871bac81a3bb5ece3ccfaaad8e3144bd2cf21acd7d525cd3d32c874"
+}

--- a/backend/.sqlx/query-2fb1603a94dcee6421c8806c5cd91504fd50474f21eddc881dbaf6db4facad91.json
+++ b/backend/.sqlx/query-2fb1603a94dcee6421c8806c5cd91504fd50474f21eddc881dbaf6db4facad91.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, part_number, name, description, kind, created_at, updated_at\n        FROM parts\n        ",
+  "query": "UPDATE parts\n        SET part_number = $1,\n            name = $2,\n            description = $3,\n            kind = $4,\n            updated_at = NOW()\n        WHERE id = $5\n        RETURNING id, part_number, name, description, kind, created_at, created_by, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -35,12 +35,23 @@
       },
       {
         "ordinal": 6,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
-      "Left": []
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Uuid"
+      ]
     },
     "nullable": [
       false,
@@ -49,8 +60,9 @@
       true,
       true,
       true,
+      true,
       true
     ]
   },
-  "hash": "67a73815d4a2814f0ee52c16861d24bb1687304fc3e1574c695a0be182779b4f"
+  "hash": "2fb1603a94dcee6421c8806c5cd91504fd50474f21eddc881dbaf6db4facad91"
 }

--- a/backend/.sqlx/query-518e2aa5d62f887acaf2c6c239593bdf7dddc3a1273e19f877ade90ec7e7b835.json
+++ b/backend/.sqlx/query-518e2aa5d62f887acaf2c6c239593bdf7dddc3a1273e19f877ade90ec7e7b835.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "INSERT INTO parts (id, part_number, name, description, kind)\n           VALUES ($1, $2, $3, $4, $5)\n           RETURNING id, part_number, name, description, kind, created_at, updated_at",
+  "query": "INSERT INTO parts (id, part_number, name, description, kind, created_by)\n           VALUES ($1, $2, $3, $4, $5, $6)\n           RETURNING id, part_number, name, description, kind, created_at, created_by, updated_at",
   "describe": {
     "columns": [
       {
@@ -35,6 +35,11 @@
       },
       {
         "ordinal": 6,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
@@ -45,7 +50,8 @@
         "Text",
         "Text",
         "Text",
-        "Text"
+        "Text",
+        "Uuid"
       ]
     },
     "nullable": [
@@ -55,8 +61,9 @@
       true,
       true,
       true,
+      true,
       true
     ]
   },
-  "hash": "f43c47b8cb05bc988f6a709953460c22ee7ee36fd6f59ccad258b73ca09a16b4"
+  "hash": "518e2aa5d62f887acaf2c6c239593bdf7dddc3a1273e19f877ade90ec7e7b835"
 }

--- a/backend/.sqlx/query-681ed4485b5cea36ab267596b89e34577a090acdbbc99a3d6dbfa2fcb1bb38ed.json
+++ b/backend/.sqlx/query-681ed4485b5cea36ab267596b89e34577a090acdbbc99a3d6dbfa2fcb1bb38ed.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "UPDATE parts\n        SET part_number = $1,\n            name = $2,\n            description = $3,\n            kind = $4,\n            updated_at = NOW()\n        WHERE id = $5\n        RETURNING id, part_number, name, description, kind, created_at, updated_at\n        ",
+  "query": "SELECT id, part_number, name, description, kind, created_at, created_by, updated_at\n        FROM parts\n        WHERE id = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -35,16 +35,17 @@
       },
       {
         "ordinal": 6,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
-        "Text",
-        "Text",
-        "Text",
         "Uuid"
       ]
     },
@@ -55,8 +56,9 @@
       true,
       true,
       true,
+      true,
       true
     ]
   },
-  "hash": "ebdd0247c4252b17950c137a25e9e5d5c96668ca97e2f4533d5b80003a317305"
+  "hash": "681ed4485b5cea36ab267596b89e34577a090acdbbc99a3d6dbfa2fcb1bb38ed"
 }

--- a/backend/.sqlx/query-79de6ccb41985a6a0f0d6e69c0fc139429db9d18fbb157bf7b82a18080203454.json
+++ b/backend/.sqlx/query-79de6ccb41985a6a0f0d6e69c0fc139429db9d18fbb157bf7b82a18080203454.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, part_number, name, description, kind, created_at, updated_at\n        FROM parts\n        WHERE id = $1\n        ",
+  "query": "SELECT id, part_number, name, description, kind, created_at, created_by, updated_at\n        FROM parts\n        ",
   "describe": {
     "columns": [
       {
@@ -35,14 +35,17 @@
       },
       {
         "ordinal": 6,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
-      "Left": [
-        "Uuid"
-      ]
+      "Left": []
     },
     "nullable": [
       false,
@@ -51,8 +54,9 @@
       true,
       true,
       true,
+      true,
       true
     ]
   },
-  "hash": "4188e2affe53eb55975440c0bb79c2cc3db64b3340a12374fad4c6e973ce242a"
+  "hash": "79de6ccb41985a6a0f0d6e69c0fc139429db9d18fbb157bf7b82a18080203454"
 }

--- a/backend/migrations/20250505014021_add_created_by_to_parts.sql
+++ b/backend/migrations/20250505014021_add_created_by_to_parts.sql
@@ -1,0 +1,1 @@
+ALTER TABLE parts ADD COLUMN created_by UUID REFERENCES users(id);

--- a/backend/src/auth/domain.rs
+++ b/backend/src/auth/domain.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Claims {
     pub sub: String,
     pub exp: usize,

--- a/backend/src/part/domain.rs
+++ b/backend/src/part/domain.rs
@@ -12,6 +12,7 @@ pub struct Part {
     pub description: Option<String>,
     pub kind: Option<String>,
     pub created_at: Option<DateTime<Utc>>,
+    pub created_by: Option<Uuid>,
     pub updated_at: Option<DateTime<Utc>>,
 }
 

--- a/backend/src/part/route.rs
+++ b/backend/src/part/route.rs
@@ -1,3 +1,4 @@
+use crate::auth::domain::Claims;
 use crate::errors::app_error::AppError;
 use crate::errors::validation::ValidationErrorResponse;
 use crate::part::domain::{NewPart, Part};
@@ -10,6 +11,7 @@ use crate::responses::error::ErrorResponse;
 use crate::responses::success::SuccessResponse;
 // use crate::services::part_service::PartService;
 
+use axum::Extension;
 use axum::{Json, extract::Path, extract::State};
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -22,10 +24,11 @@ use uuid::Uuid;
     (status = 500, description = "Database error", body = ErrorResponse),
 ), tags = ["parts"], security(("bearerAuth" = [])))]
 pub async fn create_part(
+    Extension(claims): Extension<Claims>,
     State(pool): State<PgPool>,
     Json(new_part): Json<NewPart>,
 ) -> Result<Json<SuccessResponse<Part>>, AppError> {
-    let part = service_create_part(&pool, new_part).await?;
+    let part = service_create_part(claims, &pool, new_part).await?;
     Ok(Json(SuccessResponse::created(part)))
 }
 
@@ -66,11 +69,12 @@ pub async fn get_part(
     (status = 500, description = "Database error", body = ErrorResponse),
 ), tags = ["parts"], security(("bearerAuth" = [])))]
 pub async fn update_part(
+    Extension(claims): Extension<Claims>,
     State(pool): State<PgPool>,
     Path(id): Path<Uuid>,
     Json(updated_part): Json<NewPart>,
 ) -> Result<Json<SuccessResponse<Part>>, AppError> {
-    let part = service_update_part(&pool, id, updated_part).await?;
+    let part = service_update_part(claims, &pool, id, updated_part).await?;
     Ok(Json(SuccessResponse::ok(part)))
 }
 
@@ -82,9 +86,10 @@ pub async fn update_part(
     (status = 500, description = "Database error", body = ErrorResponse),
 ), tags = ["parts"], security(("bearerAuth" = [])))]
 pub async fn delete_part(
+    Extension(claims): Extension<Claims>,
     State(pool): State<PgPool>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<SuccessResponse<()>>, AppError> {
-    service_delete_part(&pool, id).await?;
+    service_delete_part(claims, &pool, id).await?;
     Ok(Json(SuccessResponse::no_content()))
 }

--- a/backend/src/part/service/auth.rs
+++ b/backend/src/part/service/auth.rs
@@ -1,0 +1,24 @@
+use sqlx::PgPool;
+use tracing::error;
+use uuid::Uuid;
+
+use crate::{auth::domain::Claims, errors::app_error::AppError};
+
+pub async fn ensure_part_owner(claims: Claims, pool: &PgPool, id: Uuid) -> Result<(), AppError> {
+    let part_owner = sqlx::query_scalar!("SELECT created_by FROM parts WHERE ID = $1", id)
+        .fetch_one(pool)
+        .await
+        .map_err(|e| {
+            error!("DB error during ownership check: {}", e);
+            AppError::DatabaseError("Ownership check failed".into())
+        })?;
+
+    let user_id = Uuid::parse_str(&claims.sub)
+        .map_err(|e| AppError::InternalError(format!("Invalid UUID in claims: {}", e)))?;
+
+    if part_owner != Some(user_id) {
+        Err(AppError::Unauthorized("You do not own this part.".into()))
+    } else {
+        Ok(())
+    }
+}

--- a/backend/src/part/service/create.rs
+++ b/backend/src/part/service/create.rs
@@ -1,3 +1,4 @@
+use crate::auth::domain::Claims;
 use crate::errors::app_error::AppError;
 use crate::errors::validation::extract_validation_errors;
 use crate::part::domain::{NewPart, Part};
@@ -7,21 +8,29 @@ use tracing::{error, info};
 use uuid::Uuid;
 use validator::Validate;
 
-pub async fn create_part(pool: &PgPool, new_part: NewPart) -> Result<Part, AppError> {
+pub async fn create_part(
+    claims: Claims,
+    pool: &PgPool,
+    new_part: NewPart,
+) -> Result<Part, AppError> {
     new_part
         .validate()
         .map_err(|e| AppError::ValidationError(extract_validation_errors(e)))?;
 
+    let user_id = Uuid::parse_str(&claims.sub)
+        .map_err(|e| AppError::InternalError(format!("Invalid UUID in claims: {}", e)))?;
+
     let part = sqlx::query_as!(
         Part,
-        r#"INSERT INTO parts (id, part_number, name, description, kind)
-           VALUES ($1, $2, $3, $4, $5)
-           RETURNING id, part_number, name, description, kind, created_at, updated_at"#,
+        r#"INSERT INTO parts (id, part_number, name, description, kind, created_by)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           RETURNING id, part_number, name, description, kind, created_at, created_by, updated_at"#,
         Uuid::new_v4(),
         new_part.part_number,
         new_part.name,
         new_part.description,
-        new_part.kind
+        new_part.kind,
+        user_id
     )
     .fetch_one(pool)
     .await

--- a/backend/src/part/service/delete.rs
+++ b/backend/src/part/service/delete.rs
@@ -1,10 +1,14 @@
-use crate::errors::app_error::AppError;
+use crate::{auth::domain::Claims, errors::app_error::AppError};
 
 use sqlx::PgPool;
 use tracing::{error, info};
 use uuid::Uuid;
 
-pub async fn delete_part(pool: &PgPool, id: Uuid) -> Result<(), AppError> {
+use super::auth::ensure_part_owner;
+
+pub async fn delete_part(claims: Claims, pool: &PgPool, id: Uuid) -> Result<(), AppError> {
+    ensure_part_owner(claims, pool, id).await?;
+
     let result = sqlx::query!(r#"DELETE FROM parts WHERE id = $1"#, id)
         .execute(pool)
         .await

--- a/backend/src/part/service/get.rs
+++ b/backend/src/part/service/get.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 pub async fn get_parts(pool: &PgPool) -> Result<Vec<Part>, AppError> {
     let parts = sqlx::query_as!(
         Part,
-        r#"SELECT id, part_number, name, description, kind, created_at, updated_at
+        r#"SELECT id, part_number, name, description, kind, created_at, created_by, updated_at
         FROM parts
         "#
     )
@@ -26,7 +26,7 @@ pub async fn get_parts(pool: &PgPool) -> Result<Vec<Part>, AppError> {
 pub async fn get_part(pool: &PgPool, id: Uuid) -> Result<Part, AppError> {
     let part = sqlx::query_as!(
         Part,
-        r#"SELECT id, part_number, name, description, kind, created_at, updated_at
+        r#"SELECT id, part_number, name, description, kind, created_at, created_by, updated_at
         FROM parts
         WHERE id = $1
         "#,

--- a/backend/src/part/service/mod.rs
+++ b/backend/src/part/service/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod create;
 pub mod delete;
 pub mod get;

--- a/tests/api/part/api_test.sh
+++ b/tests/api/part/api_test.sh
@@ -79,6 +79,29 @@ if [ "$update_code" != "400" ]; then
 fi
 echo "✅ Validation for update worked"
 
+echo "=== 🧪 Signing up as second user ==="
+signup_res2=$(curl -s -X POST "$API_URL/signup" \
+  -H "Content-Type: application/json" \
+  -d '{"login_name":"otheruser","password":"pass456"}')
+
+login_res2=$(curl -s -X POST "$API_URL/login" \
+  -H "Content-Type: application/json" \
+  -d '{"login_name":"otheruser","password":"pass456"}')
+
+token2=$(echo "$login_res2" | jq -r '.data.token')
+AUTH_HEADER2="Authorization: Bearer $token2"
+
+echo "=== 🧪 Trying to delete another user's part ==="
+unauth_delete=$(curl -s -X DELETE "$API_URL/parts/$part_id" \
+  -H "$AUTH_HEADER2")
+
+code=$(echo "$unauth_delete" | jq -r '.code')
+if [ "$code" != "401" ]; then
+  echo "❌ Unauthorized delete should fail, got: $code"
+  exit 1
+fi
+echo "✅ Unauthorized delete blocked"
+
 echo "=== 🧪 Deleting part ==="
 delete_res=$(curl -s -X DELETE "$API_URL/parts/$part_id" \
   -H "$AUTH_HEADER")


### PR DESCRIPTION
## 🔒 Part 所有者ベースの認可を導入

この PR では、Part に対して「作成者のみが更新・削除できる」という所有者認可を追加しました。

### ✅ 主な変更点

- `parts` テーブルに `created_by` カラムを追加
- Part 作成時に JWT の `sub` を元に作成者の UUID を保存
- `update_part`, `delete_part` にて `created_by` をチェック
- 所有者チェック用の共通関数 `ensure_part_owner()` を `service/auth.rs` に切り出し
- Axum の `Extension<Claims>` を使い、各ルートで認証情報を取得
- 他ユーザーによる削除をブロックする統合テストを追加（`api_test.sh`）

### 🧪 動作確認済み

- [x] `cargo test` でユニットテスト通過
- [x] `docker-compose.backend.test.yml` で API 統合テスト通過

### 📌 関連 Issue

Issue #31 の「所有者認可」部分を実装しています。  
**ロールベースアクセス制御（RBAC）は別の PR で対応予定です。**

---

何かご指摘・改善点があればお願いします。
