### PR TITLE
refactor: Convert role string to Role enum for safer comparisons

### DIFF
--- a/backend/src/auth/domain.rs
+++ b/backend/src/auth/domain.rs
@@ -4,7 +4,7 @@ use utoipa::ToSchema;
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Claims {
     pub sub: String,
-    pub role: String,
+    pub role: Role,
     pub exp: usize,
 }
 
@@ -28,4 +28,21 @@ pub struct LoginRequest {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct LoginResponse {
     pub token: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub enum Role {
+    Admin,
+    User,
+    Unknown(String),
+}
+
+impl From<&str> for Role {
+    fn from(s: &str) -> Self {
+        match s {
+            "admin" => Role::Admin,
+            "user" => Role::User,
+            other => Role::Unknown(other.to_string()),
+        }
+    }
 }

--- a/backend/src/auth/service/login.rs
+++ b/backend/src/auth/service/login.rs
@@ -1,6 +1,6 @@
 use crate::{
     auth::{
-        domain::{Claims, LoginRequest, LoginResponse},
+        domain::{Claims, LoginRequest, LoginResponse, Role},
         jwt::generate_jwt,
         password::verify_password,
     },
@@ -40,7 +40,7 @@ pub async fn login(pool: &PgPool, payload: LoginRequest) -> Result<LoginResponse
 
     let claims = Claims {
         sub: user.id.to_string(),
-        role: user.role.clone(),
+        role: Role::from(user.role.as_str()),
         exp: expiration,
     };
 

--- a/backend/src/part/service/auth.rs
+++ b/backend/src/part/service/auth.rs
@@ -2,7 +2,10 @@ use sqlx::PgPool;
 use tracing::error;
 use uuid::Uuid;
 
-use crate::{auth::domain::Claims, errors::app_error::AppError};
+use crate::{
+    auth::domain::{Claims, Role},
+    errors::app_error::AppError,
+};
 
 pub async fn ensure_part_owner(claims: Claims, pool: &PgPool, id: Uuid) -> Result<(), AppError> {
     let part_owner = sqlx::query_scalar!("SELECT created_by FROM parts WHERE ID = $1", id)
@@ -33,7 +36,7 @@ pub async fn ensure_admin_or_owner(
     pool: &PgPool,
     id: Uuid,
 ) -> Result<(), AppError> {
-    if claims.role == "admin" {
+    if claims.role == Role::Admin {
         Ok(())
     } else {
         ensure_part_owner(claims, pool, id).await


### PR DESCRIPTION
### 📌 概要

`Claims.role` を `String` から `Role` enum に置き換え、ロール判定の安全性と可読性を高めました。

### ✨ 主な変更点

* `Role` enum を追加（`Admin`, `User`, `Unknown`）
* `From<&str>` 実装により JWT のロール文字列から enum へ変換
* `Claims` 構造体を更新し `role: Role` に変更
* `ensure_admin_or_owner` 等の判定ロジックを `== Role::Admin` に修正

### ✅ 効果

* タイポや予期しない文字列による不具合を防止
* ロール管理の拡張性が向上（将来的に他のロール追加が容易）